### PR TITLE
Disable shared key access on storage

### DIFF
--- a/iac/bicep/modules/sqldb.bicep
+++ b/iac/bicep/modules/sqldb.bicep
@@ -101,6 +101,18 @@ resource audit_storage_account 'Microsoft.Storage/storageAccounts@2023-01-01' ex
   scope: resourceGroup(auditrg)
 }
 
+module storage_permissions 'storage-permissions.bicep' = {
+  name: 'storage_permissions'
+  scope: resourceGroup(auditrg)
+  params:{
+    storage_name: audit_storage_name
+    storage_rg: auditrg
+    principalId: sqlserver.identity.principalId
+    grant_reader: false
+    grant_contributor: true
+  }
+}
+
 // Deploy audit diagnostics Azure SQL Server to storage account
 resource sqlserver_audit 'Microsoft.Sql/servers/auditingSettings@2023-08-01-preview' = {
   name: 'default'

--- a/iac/bicep/modules/storage-permissions.bicep
+++ b/iac/bicep/modules/storage-permissions.bicep
@@ -1,0 +1,55 @@
+@description('Resource name storage account to which permissions are to be granted')
+param storage_name string
+
+@description('Resource group of storage account')
+param storage_rg string
+
+@description('Managed Identity of the resource being granted permissions')
+param principalId string
+
+@description('Flag to grant Storage Blob Data Reader role to the storage account')
+param grant_reader bool = true
+
+@description('Flag to grant Storage Blob Data Contributor role to the storage account')
+param grant_contributor bool = true
+
+//Get Reference to storage account
+resource storage_account 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
+  name: storage_name
+  scope: resourceGroup(storage_rg)
+}
+
+//In-built role definition for storage account
+@description('This is the built-in Storage Blob Contributor role. See https://docs.microsoft.com/azure/role-based-access-control/built-in-roles')
+resource sbdcRoleDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  name: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+}
+
+@description('This is the built-in Storage Blob Reader role. See https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor')
+resource sbdrRoleDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  name: 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
+}
+
+//Grant Storage Blob Data Contributor role to resource
+resource grant_sbdc_role 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (grant_contributor) {
+  name: guid(subscription().subscriptionId, principalId, sbdcRoleDefinition.id)
+  // scope: storage_account
+  properties: {
+    principalType: 'ServicePrincipal'
+    principalId: principalId
+    roleDefinitionId: sbdcRoleDefinition.id
+  }
+}
+
+//Grant Storage Blob Data Reader role to resource
+resource grant_sbdr_role 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (grant_reader) {
+  name: guid(subscription().subscriptionId, principalId, sbdrRoleDefinition.id)
+  // scope: storage_account
+  properties: {
+    principalType: 'ServicePrincipal'
+    principalId: principalId
+    roleDefinitionId: sbdrRoleDefinition.id
+  }
+}

--- a/iac/bicep/modules/storage-permissions.bicep
+++ b/iac/bicep/modules/storage-permissions.bicep
@@ -35,7 +35,7 @@ resource sbdrRoleDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-
 //Grant Storage Blob Data Contributor role to resource
 resource grant_sbdc_role 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (grant_contributor) {
   name: guid(subscription().subscriptionId, principalId, sbdcRoleDefinition.id)
-  // scope: storage_account
+  scope: storage_account
   properties: {
     principalType: 'ServicePrincipal'
     principalId: principalId
@@ -46,7 +46,7 @@ resource grant_sbdc_role 'Microsoft.Authorization/roleAssignments@2020-04-01-pre
 //Grant Storage Blob Data Reader role to resource
 resource grant_sbdr_role 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (grant_reader) {
   name: guid(subscription().subscriptionId, principalId, sbdrRoleDefinition.id)
-  // scope: storage_account
+  scope: storage_account
   properties: {
     principalType: 'ServicePrincipal'
     principalId: principalId


### PR DESCRIPTION
This pull request introduces a new module for managing storage permissions in Azure Bicep files. The changes include adding a new module to the `sqldb.bicep` file and defining the module in a new `storage-permissions.bicep` file. The new module grants specific roles to a storage account based on parameters.

### New Module Addition:
* [`iac/bicep/modules/sqldb.bicep`](diffhunk://#diff-79986cca3e3e8c4a39d9466774f70cc0c2b4f58bdccf9d0444f013bc82c5d80fR104-R115): Added a new module `storage_permissions` to manage storage account permissions. This module takes parameters such as `storage_name`, `storage_rg`, `principalId`, `grant_reader`, and `grant_contributor`.

### Module Definition:
* [`iac/bicep/modules/storage-permissions.bicep`](diffhunk://#diff-efeb075ca8f0daa9ea7df051169a864e69dbb251e3c9dc6b3754ef421ab87e5eR1-R55): Defined the new `storage_permissions` module to grant Storage Blob Data Reader and Contributor roles to a specified storage account. The module includes parameters for resource name, resource group, principal ID, and flags to grant specific roles.