### PR TITLE
Disabled SQL Server audit temporarily

### DIFF
--- a/iac/bicep/main.bicep
+++ b/iac/bicep/main.bicep
@@ -167,6 +167,7 @@ module controldb './modules/sqldb.bicep' = {
      database_sku_name: 'GP_S_Gen5_1' 
      enable_purview: enable_purview
      purview_resource: enable_purview ? purview.outputs.purview_resource : {}
+     enable_audit: false
      audit_storage_name: audit_integration.outputs.audit_storage_uniquename
      auditrg: audit_rg.name
   }

--- a/iac/bicep/modules/sqldb.bicep
+++ b/iac/bicep/modules/sqldb.bicep
@@ -33,6 +33,9 @@ param auto_pause_duration int =60
 @description('Flag to indicate whether to enable integration of data platform resources with either an existing or new Purview resource')
 param enable_purview bool
 
+@description('Flag to indicate whether to enable audit logging of SQL Server')
+param enable_audit bool = false
+
 @description('Resource Name of new or existing Purview Account. Specify a resource name if create_purview=true or enable_purview=true')
 param purview_resource object
 
@@ -101,7 +104,7 @@ resource audit_storage_account 'Microsoft.Storage/storageAccounts@2023-01-01' ex
   scope: resourceGroup(auditrg)
 }
 
-module storage_permissions 'storage-permissions.bicep' = {
+module storage_permissions 'storage-permissions.bicep' = if(enable_audit)  {
   name: 'storage_permissions'
   scope: resourceGroup(auditrg)
   params:{
@@ -114,7 +117,7 @@ module storage_permissions 'storage-permissions.bicep' = {
 }
 
 // Deploy audit diagnostics Azure SQL Server to storage account
-resource sqlserver_audit 'Microsoft.Sql/servers/auditingSettings@2023-08-01-preview' = {
+resource sqlserver_audit 'Microsoft.Sql/servers/auditingSettings@2023-08-01-preview' = if(enable_audit)  {
   name: 'default'
   parent: sqlserver
   properties: {

--- a/iac/bicep/modules/storage-permissions.bicep
+++ b/iac/bicep/modules/storage-permissions.bicep
@@ -35,7 +35,7 @@ resource sbdrRoleDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-
 //Grant Storage Blob Data Contributor role to resource
 resource grant_sbdc_role 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (grant_contributor) {
   name: guid(subscription().subscriptionId, principalId, sbdcRoleDefinition.id)
-  scope: storage_account
+  // scope: storage_account //needs to be uncommented when this is supported
   properties: {
     principalType: 'ServicePrincipal'
     principalId: principalId
@@ -46,7 +46,7 @@ resource grant_sbdc_role 'Microsoft.Authorization/roleAssignments@2020-04-01-pre
 //Grant Storage Blob Data Reader role to resource
 resource grant_sbdr_role 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (grant_reader) {
   name: guid(subscription().subscriptionId, principalId, sbdrRoleDefinition.id)
-  scope: storage_account
+  // scope: storage_account //needs to be uncommented when this is supported
   properties: {
     principalType: 'ServicePrincipal'
     principalId: principalId


### PR DESCRIPTION
This pull request introduces several changes to the Bicep infrastructure code, primarily focusing on adding support for audit logging and adjusting role assignments. The most important changes include adding parameters and conditions for enabling audit logging, and modifying role assignment scopes.

### Audit Logging Enhancements:
* [`iac/bicep/main.bicep`](diffhunk://#diff-4459560fe509427f986d3195837ebc6be6fa74c023911cc018c21d57edc1e1f2R170): Added `enable_audit` parameter with a default value of `false` and updated the module configuration to include this parameter.
* [`iac/bicep/modules/sqldb.bicep`](diffhunk://#diff-79986cca3e3e8c4a39d9466774f70cc0c2b4f58bdccf9d0444f013bc82c5d80fR36-R38): Introduced `enable_audit` parameter and updated the `storage_permissions` and `sqlserver_audit` resources to be conditionally deployed based on this parameter. [[1]](diffhunk://#diff-79986cca3e3e8c4a39d9466774f70cc0c2b4f58bdccf9d0444f013bc82c5d80fR36-R38) [[2]](diffhunk://#diff-79986cca3e3e8c4a39d9466774f70cc0c2b4f58bdccf9d0444f013bc82c5d80fL104-R107) [[3]](diffhunk://#diff-79986cca3e3e8c4a39d9466774f70cc0c2b4f58bdccf9d0444f013bc82c5d80fL117-R120)

### Role Assignment Adjustments:
* [`iac/bicep/modules/storage-permissions.bicep`](diffhunk://#diff-efeb075ca8f0daa9ea7df051169a864e69dbb251e3c9dc6b3754ef421ab87e5eL38-R38): Commented out the `scope` property in `grant_sbdc_role` and `grant_sbdr_role` resources, indicating it needs to be uncommented when supported. [[1]](diffhunk://#diff-efeb075ca8f0daa9ea7df051169a864e69dbb251e3c9dc6b3754ef421ab87e5eL38-R38) [[2]](diffhunk://#diff-efeb075ca8f0daa9ea7df051169a864e69dbb251e3c9dc6b3754ef421ab87e5eL49-R49)