### PR TITLE
Update Bicep modules to conditionally set audit storage parameters basedsed on enable_audit flag

### DIFF
--- a/iac/bicep/main.bicep
+++ b/iac/bicep/main.bicep
@@ -168,7 +168,7 @@ module controldb './modules/sqldb.bicep' = {
      enable_purview: enable_purview
      purview_resource: enable_purview ? purview.outputs.purview_resource : {}
      enable_audit: false
-     audit_storage_name: audit_integration.outputs.audit_storage_uniquename
-     auditrg: audit_rg.name
+     audit_storage_name: enable_audit?audit_integration.outputs.audit_storage_uniquename:''
+     auditrg: enable_audit?audit_rg.name:''
   }
 }

--- a/iac/bicep/modules/sqldb.bicep
+++ b/iac/bicep/modules/sqldb.bicep
@@ -99,7 +99,7 @@ resource database 'Microsoft.Sql/servers/databases@2021-11-01' ={
 }
 
 //Get Reference to audit storage account
-resource audit_storage_account 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
+resource audit_storage_account 'Microsoft.Storage/storageAccounts@2023-01-01' existing = if(enable_audit) {
   name: audit_storage_name
   scope: resourceGroup(auditrg)
 }


### PR DESCRIPTION
This pull request includes changes to the `iac/bicep` files to conditionally enable auditing features based on the `enable_audit` flag. The changes ensure that audit-related resources are only defined and referenced when auditing is enabled.

Conditional auditing features:

* [`iac/bicep/main.bicep`](diffhunk://#diff-4459560fe509427f986d3195837ebc6be6fa74c023911cc018c21d57edc1e1f2L171-R172): Modified the `audit_storage_name` and `auditrg` properties to use conditional expressions based on the `enable_audit` flag.
* [`iac/bicep/modules/sqldb.bicep`](diffhunk://#diff-79986cca3e3e8c4a39d9466774f70cc0c2b4f58bdccf9d0444f013bc82c5d80fL102-R102): Changed the `audit_storage_account` resource definition to be conditional based on the `enable_audit` flag.