### PR TITLE
Update default value for purview_name parameter to 'ContosoDG' for clarity

### DIFF
--- a/iac/bicep/main.bicep
+++ b/iac/bicep/main.bicep
@@ -33,7 +33,7 @@ param purviewrg string= 'rg-datagovernance'
 param purview_location string= 'westus2'
 
 @description('Resource Name of new or existing Purview Account. Must be globally unique. Specify a resource name if either create_purview=true or enable_purview=true')
-param purview_name string = '<Gloablly Unique Purview Name>'
+param purview_name string = 'ContosoDG' // Replace with a Globally unique name
 
 @description('Flag to indicate whether auditing of data platform resources should be enabled')
 param enable_audit bool = true


### PR DESCRIPTION
This pull request includes a change to the `iac/bicep/main.bicep` file to update the default value of the `purview_name` parameter.

* [`iac/bicep/main.bicep`](diffhunk://#diff-4459560fe509427f986d3195837ebc6be6fa74c023911cc018c21d57edc1e1f2L36-R36): Changed the default value of the `purview_name` parameter from a placeholder string to 'ContosoDG' with a comment indicating it should be replaced with a globally unique name.