### PR TITLE
Set file format to parquet in copy activity

### DIFF
--- a/workspace/Ingest ASQL Table.DataPipeline/pipeline-content.json
+++ b/workspace/Ingest ASQL Table.DataPipeline/pipeline-content.json
@@ -127,14 +127,13 @@
             }
           },
           "sink": {
-            "type": "DelimitedTextSink",
+            "type": "ParquetSink",
             "storeSettings": {
               "type": "LakehouseWriteSettings"
             },
             "formatSettings": {
-              "type": "DelimitedTextWriteSettings",
-              "quoteAllText": true,
-              "fileExtension": ".txt"
+              "type": "ParquetWriteSettings",
+              "enableVertiParquet": true
             },
             "datasetSettings": {
               "annotations": [],
@@ -150,7 +149,7 @@
                   }
                 }
               },
-              "type": "DelimitedText",
+              "type": "Parquet",
               "typeProperties": {
                 "location": {
                   "type": "LakehouseLocation",
@@ -163,10 +162,7 @@
                     "type": "Expression"
                   }
                 },
-                "columnDelimiter": ",",
-                "escapeChar": "\\",
-                "firstRowAsHeader": true,
-                "quoteChar": "\""
+                "compressionCodec": "snappy"
               },
               "schema": []
             }


### PR DESCRIPTION
This pull request includes changes to the `workspace/Ingest ASQL Table.DataPipeline/pipeline-content.json` file to switch the data format from delimited text to Parquet. This change improves data efficiency and performance.

Changes to data format:

* Changed the sink type from `DelimitedTextSink` to `ParquetSink`.
* Updated the format settings to use `ParquetWriteSettings` and enabled `VertiParquet`.
* Changed the dataset type from `DelimitedText` to `Parquet`.
* Replaced delimited text properties (e.g., `columnDelimiter`, `escapeChar`, `firstRowAsHeader`, `quoteChar`) with Parquet-specific property `compressionCodec` set to `snappy`.