### PR TITLE
Update default SKU name for Fabric Capacity to 'F2' in Bicep modules

### DIFF
--- a/iac/bicep/main.bicep
+++ b/iac/bicep/main.bicep
@@ -147,6 +147,7 @@ module fabric_capacity './modules/fabric-capacity.bicep' = {
     owner_tag: owner_tag
     sme_tag: sme_tag
     adminUsers: kv_ref.getSecret('fabric-capacity-admin-username')
+    skuName: 'F4' // Default Fabric Capacity SKU F2
   }
 }
 

--- a/iac/bicep/modules/fabric-capacity.bicep
+++ b/iac/bicep/modules/fabric-capacity.bicep
@@ -28,7 +28,7 @@ param sme_tag string
   'F1024'
   'F2048'
 ])
-param skuName string = 'F64'
+param skuName string = 'F2'
 
 @description('The SKU tier of the Fabric Capacity instance.')
 param skuTier string = 'Fabric'


### PR DESCRIPTION
This pull request includes changes to the `iac/bicep` files to update the default SKU for the Fabric Capacity module. The most important changes include updating the default `skuName` parameter and setting a new default SKU in the main Bicep file.

Updates to default SKU:

* [`iac/bicep/modules/fabric-capacity.bicep`](diffhunk://#diff-b94fef50a4e6eaa041e7ef212762067a6bea2982318d1a9130ebd7a0e869a2d3L31-R31): Changed the default `skuName` parameter from 'F64' to 'F2'.
* [`iac/bicep/main.bicep`](diffhunk://#diff-4459560fe509427f986d3195837ebc6be6fa74c023911cc018c21d57edc1e1f2R150): Set the `skuName` to 'F4' in the Fabric Capacity module configuration.