### PR TITLE
Added new functions to read LH tables

### DIFF
--- a/workspace/UnitTest_DeltaLakeFunctions.Notebook/notebook-content.py
+++ b/workspace/UnitTest_DeltaLakeFunctions.Notebook/notebook-content.py
@@ -74,3 +74,123 @@ optimizeDelta("silver_sales_customertransactions")
 # META   "language": "python",
 # META   "language_group": "synapse_pyspark"
 # META }
+
+# CELL ********************
+
+df = readMedallionLHTable("silver","Tables/dbo/silver_warehouse_colors")
+display(df)
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
+
+# CELL ********************
+
+df = readMedallionLHTable("silver","Tables/dbo/silver_warehouse_colors","ColorName == 'Salmon'")
+display(df)
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
+
+# CELL ********************
+
+df = readMedallionLHTable("silver","Tables/dbo/silver_warehouse_colors","ColorName == 'Salmon'",["ColorID","ColorName"])
+display(df)
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
+
+# CELL ********************
+
+df = readMedallionLHTable("silver","Tables/dbo/silver_warehouse_colors",None,["ColorID","ColorName"])
+display(df)
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
+
+# CELL ********************
+
+df = readMedallionLHTable("silver","Tables/dbo/silver_warehouse_colors","ColorName == 'Salmon'",None)
+display(df)
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
+
+# CELL ********************
+
+df = readLHTable("lh_fabricEvents","Tables/jobs/pipelineJobs","582b9e24-0962-4fd0-aee5-647d9c200685", filterCond=None, colList=None)
+display(df)
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
+
+# CELL ********************
+
+df = readLHTable("lh_fabricEvents","Tables/jobs/pipelineJobs","582b9e24-0962-4fd0-aee5-647d9c200685", "EventProcessedUtcTime >'2025-02-07 20:42:19.269818'", colList=None)
+display(df)
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
+
+# CELL ********************
+
+df = readLHTable("lh_fabricEvents","Tables/jobs/pipelineJobs","582b9e24-0962-4fd0-aee5-647d9c200685", "EventProcessedUtcTime >'2025-02-07 20:42:19.269818'", ["id","data","EventProcessedUtcTime"])
+display(df)
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
+
+# CELL ********************
+
+df = readLHTable("lh_fabricEvents","Tables/jobs/pipelineJobs","582b9e24-0962-4fd0-aee5-647d9c200685", "EventProcessedUtcTime >'2025-02-07 20:42:19.269818'", None)
+display(df)
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
+
+# CELL ********************
+
+df = readLHTable("lh_fabricEvents","Tables/jobs/pipelineJobs","582b9e24-0962-4fd0-aee5-647d9c200685", None, ["id","data","EventProcessedUtcTime"])
+display(df)
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }


### PR DESCRIPTION
This pull request includes significant updates to the `workspace/DeltaLakeFunctions&#32;.Notebook/notebook-content.py` and `workspace/UnitTest_DeltaLakeFunctions.Notebook/notebook-content.py` files. The most important changes include the addition of new functions for reading Lakehouse tables and the inclusion of corresponding unit tests.

New functions for reading Lakehouse tables:

* [`workspace/DeltaLakeFunctions&#32;.Notebook/notebook-content.py`](diffhunk://#diff-c76b49a70ebe75e09177798f343af9b2757cc5629334a958857a8fdbb7586c9aR161-R271): Added `readMedallionLHTable` function to retrieve a Lakehouse Table from the medallion layers, allowing for table filtering and specific column selection.
* [`workspace/DeltaLakeFunctions&#32;.Notebook/notebook-content.py`](diffhunk://#diff-c76b49a70ebe75e09177798f343af9b2757cc5629334a958857a8fdbb7586c9aR161-R271): Added `readLHTable` function to retrieve any Lakehouse Table from OneLake, allowing for table filtering and specific column selection.

Unit tests for new functions:

* [`workspace/UnitTest_DeltaLakeFunctions.Notebook/notebook-content.py`](diffhunk://#diff-4e39ddc3e3076dc8568b2fc676c060491b35f1e973111e9780adac4c50e2cd8aR77-R196): Added unit tests for `readMedallionLHTable` function with various filter conditions and column selections.
* [`workspace/UnitTest_DeltaLakeFunctions.Notebook/notebook-content.py`](diffhunk://#diff-4e39ddc3e3076dc8568b2fc676c060491b35f1e973111e9780adac4c50e2cd8aR77-R196): Added unit tests for `readLHTable` function with various filter conditions and column selections.

Additional improvements:

* [`workspace/DeltaLakeFunctions&#32;.Notebook/notebook-content.py`](diffhunk://#diff-c76b49a70ebe75e09177798f343af9b2757cc5629334a958857a8fdbb7586c9aR36): Imported `pyspark.sql.functions` to support new functionalities.