### PR TITLE
Deleted shortcut

### DIFF
--- a/workspace/lh_silver.Lakehouse/shortcuts.metadata.json
+++ b/workspace/lh_silver.Lakehouse/shortcuts.metadata.json
@@ -1,15 +1,1 @@
-[
-  {
-    "name": "raw-bronze",
-    "path": "/Files",
-    "target": {
-      "type": "OneLake",
-      "oneLake": {
-        "path": "Files/raw-bronze",
-        "itemId": "1355e38b-d635-45a7-9d21-8f02933bc81f",
-        "workspaceId": "00000000-0000-0000-0000-000000000000",
-        "artifactType": "Lakehouse"
-      }
-    }
-  }
-]
+[]


### PR DESCRIPTION
This pull request includes a small change to the `workspace/lh_silver.Lakehouse/shortcuts.metadata.json` file. The change removes the "raw-bronze" shortcut entry, leaving an empty array.

* Removed "raw-bronze" shortcut entry from `workspace/lh_silver.Lakehouse/shortcuts.metadata.json`, resulting in an empty array.