### PR TITLE
Fabric CLI Auth

### DIFF
--- a/.github/workflows/deploy-fabric-accelerator.yml
+++ b/.github/workflows/deploy-fabric-accelerator.yml
@@ -17,7 +17,7 @@ jobs:
        # Authenticate using Service Principal
         - name: Authenticate to Fabric
           run: |
-            fab auth login -u {{secrets.ACTION_SPN_CLIENTID}} -p{{sexcrets.ACTION_SPN_SECRET}} --tenant {{secrets.TENANT_ID}} 
+            fab auth login -u {{secrets.ACTION_SPN_CLIENTID}} -p{{secrets.ACTION_SPN_SECRET}} --tenant {{secrets.TENANT_ID}} 
 
         # Checkout code
         - uses: actions/checkout@v3   


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the deployment of the Fabric Accelerator. The workflow sets up the required Python environment, installs the Fabric CLI, authenticates using a service principal, and checks out the repository code.

**Deployment automation:**

* Added `.github/workflows/deploy-fabric-accelerator.yml` to define a workflow for deploying the Fabric Accelerator, including steps for setting up Python, installing the Fabric CLI, authenticating to Azure Fabric using service principal credentials, and checking out the code.