### PR TITLE
Simplify deployment

### DIFF
--- a/.github/workflows/deploy-fabric-accelerator.yml
+++ b/.github/workflows/deploy-fabric-accelerator.yml
@@ -17,6 +17,7 @@ jobs:
        # Authenticate using Service Principal
         - name: Authenticate to Fabric
           run: |
+            fab config set encryption_fallback_enabled true
             fab auth login -u {{secrets.ACTION_SPN_CLIENTID}} -p{{sexcrets.ACTION_SPN_SECRET}} --tenant {{secrets.TENANT_ID}} 
 
         # Checkout code


### PR DESCRIPTION
This pull request introduces a minor update to the deployment workflow. The change enables encryption fallback in the authentication step for Fabric deployments, likely to improve robustness or compatibility in secure environments.

* Deployment workflow:
  * [`.github/workflows/deploy-fabric-accelerator.yml`](diffhunk://#diff-5a2c86ae375c8b12ac6ce8a3e4394d4c436d2ae093955cf2c83386af67b80eb6R20): Added `fab config set encryption_fallback_enabled true` before authentication to enable encryption fallback during Fabric authentication.