### PR TITLE
Simplify deployment - Added RTI all items

### DIFF
--- a/.github/workflows/deploy-fabric-accelerator.yml
+++ b/.github/workflows/deploy-fabric-accelerator.yml
@@ -345,21 +345,21 @@ jobs:
             platform=$(jq '.' "${GITHUB_WORKSPACE}/workspace/pipeline/reusable/level2-transform/Master Level2 Transform.DataPipeline/.platform"| base64)
 
             if [ "$PipelineExists" != "*true" ]; then
-               folderId=$(fab get $WORKSPACE_NAME.Workspace/pipeline.Folder/reusable.Folder/level2-transform.Folder -q id | tr -d '\r')
-               jsonPayload=$(jq -n \
-                        --arg displayName "Master Level2 Transform" \
-                        --arg pipeline_content "$pipeline_content" \
-                        --arg platform "$platform" \
-                        --arg folderId "$folderId" \
-                        '{"displayName": $displayName,"definition": {"parts":[{"path": "pipeline-content.json","payload": $pipeline_content,"payloadType": "InlineBase64"},{"path": ".platform","payload": $platform,"payloadType": "InlineBase64"}]},"folderId": $folderId}')
-                response=$(fab api -X post "workspaces/$NEW_FABRIC_WORKSPACE_ID/dataPipelines" -i "$jsonPayload")
+              folderId=$(fab get $WORKSPACE_NAME.Workspace/pipeline.Folder/reusable.Folder/level2-transform.Folder -q id | tr -d '\r')
+              jsonPayload=$(jq -n \
+                --arg displayName "Master Level2 Transform" \
+                --arg pipeline_content "$pipeline_content" \
+                --arg platform "$platform" \
+                --arg folderId "$folderId" \
+                '{"displayName": $displayName,"definition": {"parts":[{"path": "pipeline-content.json","payload": $pipeline_content,"payloadType": "InlineBase64"},{"path": ".platform","payload": $platform,"payloadType": "InlineBase64"}]},"folderId": $folderId}')
+              response=$(fab api -X post "workspaces/$NEW_FABRIC_WORKSPACE_ID/dataPipelines" -i "$jsonPayload")
             else
-                pipelineId=$(fab get $WORKSPACE_NAME.Workspace/Master Level2 Transform.DataPipeline -q id | tr -d '\r')
-                jsonPayload=$(jq -n \
-                          --arg pipeline_content "$pipeline_content" \
-                          --arg platform "$platform" \
-                          '{"definition": {"parts":[{"path": "pipeline-content.json","payload": $pipeline_content,"payloadType": "InlineBase64"},{"path": ".platform","payload": $platform,"payloadType": "InlineBase64"}]}}')
-                response=$(fab api -X post "workspaces/$NEW_FABRIC_WORKSPACE_ID/dataPipelines/$pipelineId/updateDefinition?updateMetadata=True" -i "$jsonPayload")
+              pipelineId=$(fab get $WORKSPACE_NAME.Workspace/Master Level2 Transform.DataPipeline -q id | tr -d '\r')
+              jsonPayload=$(jq -n \
+                --arg pipeline_content "$pipeline_content" \
+                --arg platform "$platform" \
+                '{"definition": {"parts":[{"path": "pipeline-content.json","payload": $pipeline_content,"payloadType": "InlineBase64"},{"path": ".platform","payload": $platform,"payloadType": "InlineBase64"}]}}')
+              response=$(fab api -X post "workspaces/$NEW_FABRIC_WORKSPACE_ID/dataPipelines/$pipelineId/updateDefinition?updateMetadata=True" -i "$jsonPayload")
             fi  
             
             echo "$response"


### PR DESCRIPTION
This pull request updates the `deploy-fabric-accelerator.yml` GitHub Actions workflow to enhance the automation and reliability of notebook and pipeline deployment. The most significant changes are the addition of new environment variables for pipeline and notebook IDs, expanded ID replacement logic for ipynb files, and improved notebook import handling.

**Environment variable additions:**

* Added new environment variables for master ingest pipeline and optimize delta tables notebook IDs, both for new and old deployments. This supports more granular and flexible pipeline and notebook management. [[1]](diffhunk://#diff-5a2c86ae375c8b12ac6ce8a3e4394d4c436d2ae093955cf2c83386af67b80eb6R25-R30) [[2]](diffhunk://#diff-5a2c86ae375c8b12ac6ce8a3e4394d4c436d2ae093955cf2c83386af67b80eb6R44-R49)

**Notebook and pipeline ID replacement enhancements:**

* Extended the script to replace additional IDs in ipynb files, including workspace, bronze/silver/gold lakehouse, and data warehouse references, ensuring all relevant identifiers are updated during deployment.

**Notebook import and cleanup improvements:**

* Updated the notebook import process to first remove existing notebooks (if present) before importing new versions, preventing conflicts and ensuring clean updates. This includes parallel deletion and import for better performance.