### PR TITLE
Simplify deployment - Fixed RTI Dashboard database URL

### DIFF
--- a/.github/workflows/deploy-fabric-accelerator.yml
+++ b/.github/workflows/deploy-fabric-accelerator.yml
@@ -605,6 +605,10 @@ jobs:
             DashboardExists=$(fab exists "$WORKSPACE_NAME.Workspace/fabricEventsDashboard.KQLDashboard"| tr -d '[:space:]')
             
             # Update KQL Database URL
+            if [ -z "$KQLServiceUrl" ]; then
+              echo "Error: KQLServiceUrl is not set. Aborting dashboard update." >&2
+              exit 1
+            fi
             jq --arg url "$KQLServiceUrl" '.dataSources[].clusterUri = $url' "${GITHUB_WORKSPACE}/workspace/rti/dashboard/fabricEventsDashboard.KQLDashboard/RealTimeDashboard.json" > tmp.json && mv tmp.json "${GITHUB_WORKSPACE}/workspace/rti/dashboard/fabricEventsDashboard.KQLDashboard/RealTimeDashboard.json"
             
             folderId=$(fab get $WORKSPACE_NAME.Workspace/rti.Folder/dashboard.Folder -q id | tr -d '\r')


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy-fabric-accelerator.yml` to improve notebook deployment steps and enhance the configuration of the RTI Dashboard with dynamic KQL Database URLs. The changes help clarify deployment intent and ensure the dashboard uses the correct KQL service endpoint.

**Notebook Deployment Improvements:**
- Renamed the workflow step from "Import Notebooks" to "Deploy Notebooks" for better clarity and alignment with its purpose.

**RTI Dashboard Configuration Enhancements:**
- Added logic to fetch the KQL Service URL dynamically using the `fab api` command and store it in the GitHub environment for subsequent steps.
- Updated the RTI Dashboard's `RealTimeDashboard.json` to set the `clusterUri` of all data sources to the dynamically retrieved KQL Service URL, ensuring the dashboard points to the correct database endpoint.