### PR TITLE
Add L1 Transform Generic Notebook ID handling to deployment workflow

### DIFF
--- a/.github/workflows/deploy-fabric-accelerator.yml
+++ b/.github/workflows/deploy-fabric-accelerator.yml
@@ -285,7 +285,6 @@ jobs:
             grep --null -rl "$OLD_L1_TRANSFORM_GENERIC_NOTEBOOK_ID" "${GITHUB_WORKSPACE}/workspace" | tr '\0' '\n'
             grep --null -rl $OLD_L1_TRANSFORM_GENERIC_NOTEBOOK_ID ${GITHUB_WORKSPACE}/workspace | xargs -0 sed -i "s/$OLD_L1_TRANSFORM_GENERIC_NOTEBOOK_ID/$NEW_L1_TRANSFORM_GENERIC_NOTEBOOK_ID/g"
 
-
       # Deploy Pipeline wwi-elt-framework
         - name: Deploy Pipeline wwi-elt-framework
           run: |


### PR DESCRIPTION
This pull request updates the deployment workflow for the Fabric Accelerator by introducing support for a new notebook resource, specifically the L1 Transform Generic Notebook. The main changes ensure that both old and new notebook IDs are tracked and that references to the notebook are updated during deployment.

**Notebook ID management:**

* Added `NEW_L1_TRANSFORM_GENERIC_NOTEBOOK_ID` and `OLD_L1_TRANSFORM_GENERIC_NOTEBOOK_ID` to the workflow environment variables to track the new and old IDs for the L1 Transform Generic Notebook (`.github/workflows/deploy-fabric-accelerator.yml`). [[1]](diffhunk://#diff-5a2c86ae375c8b12ac6ce8a3e4394d4c436d2ae093955cf2c83386af67b80eb6R31) [[2]](diffhunk://#diff-5a2c86ae375c8b12ac6ce8a3e4394d4c436d2ae093955cf2c83386af67b80eb6R51)

**Automated notebook reference update:**

* Implemented steps to retrieve the new notebook ID, set it as an environment variable, and update all occurrences of the old notebook ID to the new one in workspace files during deployment (`.github/workflows/deploy-fabric-accelerator.yml`).