### PR TITLE
Update deployment workflow to force database name retrieval without sensitivity label dialog

### DIFF
--- a/.github/workflows/deploy-fabric-accelerator.yml
+++ b/.github/workflows/deploy-fabric-accelerator.yml
@@ -179,7 +179,7 @@ jobs:
               NEW_FABRIC_WORKSPACE_ID=$(fab get $WORKSPACE_NAME.Workspace -q id | tr -d '\r')
               echo "NEW_FABRIC_WORKSPACE_ID=$NEW_FABRIC_WORKSPACE_ID" >> $GITHUB_ENV
              
-              NEW_CONTROLDB_NAME=$(fab get $WORKSPACE_NAME.Workspace/$FABRIC_SQL_DB_NAME.SQLDatabase -q properties.databaseName -f| tr -d '\r')
+              NEW_CONTROLDB_NAME=$(fab get $WORKSPACE_NAME.Workspace/$FABRIC_SQL_DB_NAME.SQLDatabase -q properties.databaseName -f | tr -d '\r')
               echo "NEW_CONTROLDB_NAME=$NEW_CONTROLDB_NAME" >> $GITHUB_ENV
              
               NEW_CONTROLDB_CONNECTION_ID=$(fab get .connections/"${WORKSPACE_NAME}-${FABRIC_SQL_DB_NAME}".Connection -q id | tr -d '\r')


### PR DESCRIPTION
This pull request introduces a minor update to the deployment workflow for the Fabric Accelerator. The change ensures that the command fetching the SQL database name uses the correct output formatting flag.

* Updated the `fab get` command in `.github/workflows/deploy-fabric-accelerator.yml` to include the `-f` flag when retrieving the `properties.databaseName` for the SQL database, which may improve output formatting or compatibility.