### PR TITLE
Recreate stored procedure for supplier transactions snapshot

### DIFF
--- a/workspace/warehouse/dw_gold.Warehouse/gold/StoredProcedures/mirror_create_suppliertransactions_monthly_snapshot.sql
+++ b/workspace/warehouse/dw_gold.Warehouse/gold/StoredProcedures/mirror_create_suppliertransactions_monthly_snapshot.sql
@@ -41,10 +41,8 @@ BEGIN
         SUM(spt.[AmountExcludingTax]) AS [POAmount],
         SUM(spt.[TaxAmount]) AS [TaxAmount],
         COUNT(1) AS [POCount]
-    FROM
-    FROM
-        [lh_silver].[dbo].[silver_mirror_purchasing_suppliertransactions] spt
-        INNER JOIN [lh_silver].[dbo].[silver_application_transactiontypes] tt
+    FROM [lh_silver].[dbo].[silver_mirror_purchasing_suppliertransactions] spt
+        INNER JOIN [lh_silver].[dbo].[silver_application_transactiontypes] tt
             ON tt.[TransactionTypeID] = spt.[TransactionTypeID]
     GROUP BY
         spt.[SupplierID],


### PR DESCRIPTION
This pull request makes a small correction to the SQL stored procedure `mirror_create_suppliertransactions_monthly_snapshot.sql`. The change fixes a duplicated `FROM` clause, ensuring the SQL syntax is correct.

* Fixed a duplicated `FROM` clause in the SELECT statement to prevent SQL syntax errors (`mirror_create_suppliertransactions_monthly_snapshot.sql`).