### PR TITLE
Add step to replace 'lh_silver' with dynamic SILVER_LH in Gold DW dbproj

### DIFF
--- a/.github/workflows/deploy-fabric-accelerator.yml
+++ b/.github/workflows/deploy-fabric-accelerator.yml
@@ -1194,6 +1194,21 @@ jobs:
         - name: Add msbuild to PATH
           uses: microsoft/setup-msbuild@v3  
 
+        - name: Replace lh_silver with SILVER_LH in Gold DW sources
+          shell: pwsh
+          run: |
+            $warehousePath = Join-Path "${{ github.workspace }}" "workspace\warehouse\dw_gold.Warehouse"
+            $files = Get-ChildItem -Path $warehousePath -Recurse -File |
+              Select-String -Pattern 'lh_silver' -List |
+              Select-Object -ExpandProperty Path
+
+            foreach ($file in $files) {
+              Write-Host "Updating $file"
+              $content = Get-Content $file -Raw
+              $updated = $content -replace 'lh_silver', '${{ env.SILVER_LH }}'
+              Set-Content -Path $file -Value $updated
+            }
+
         # Build the SQL project into a .dacpac using MSBuild (SSDT)
         - name: Build Gold DW dacpac
           shell: pwsh


### PR DESCRIPTION
This pull request adds a new deployment workflow step to automate replacing the literal string `lh_silver` with the environment variable value `${{ env.SILVER_LH }}` in all files within the `dw_gold.Warehouse` directory. This ensures that Gold Data Warehouse sources reference the correct Silver layer dynamically during deployment.

**Deployment automation:**

* [`.github/workflows/deploy-fabric-accelerator.yml`](diffhunk://#diff-5a2c86ae375c8b12ac6ce8a3e4394d4c436d2ae093955cf2c83386af67b80eb6R1197-R1211): Added a PowerShell step that recursively finds and updates all files in the `dw_gold.Warehouse` directory, replacing occurrences of `lh_silver` with the value of the `SILVER_LH` environment variable.…rces